### PR TITLE
Add search support to DataCite admin changelist

### DIFF
--- a/geonode_datacite/admin.py
+++ b/geonode_datacite/admin.py
@@ -25,6 +25,7 @@ class DataCiteAdmin(admin.ModelAdmin):
     model = ResourceBase
     form = DataCiteForm
     change_list_template = "admin/client/change_list.html"
+    search_fields = ("title",)
 
     def get_readonly_fields(self, request, obj=None):
         """


### PR DESCRIPTION
Problem

The DataCite admin page displays a custom changelist but does not expose
the standard Django admin search functionality, making it difficult to
locate resources in installations with many records.

Solution

Added `search_fields` to DataCiteAdmin so the standard Django admin search
box is displayed and users can search by resource title.

Tested

- GeoNode running locally via Docker
- geonode-datacite installed from local checkout
- Verified search box appears in the DataCite admin page
- Verified searches by title return the expected resources